### PR TITLE
WIP towards supporting java-style argument groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For a good overview of approaches to IPL theorem proving, see these talk slides:
 - Debugging options are available
 - Support for `Unit` type, constant types, type parameters, function types, tuples, sealed traits / case classes / case objects
 - Both conventional Scala syntax `def f[T](x: T): T` and curried syntax `def f[T]: T ⇒ T` can be used
+- Java-style argument groups can be used, e.g. `A => (B, C) => D`, which is not the same as using a tuple type: `A => ((B, C)) => D`
 - When a type can be implemented in more than one way, heuristics ("least information loss") are used to prefer implementations that are more likely to satisfy algebraic laws
 - Signal error when a type can be implemented in more than one way despite using heuristics
 - Tests and a tutorial
@@ -130,8 +131,7 @@ For a good overview of approaches to IPL theorem proving, see these talk slides:
 
 # Known bugs
 
-- Limited support for recursive case classes (including `List`): generated code cannot contain recursive functions
-- No support for the conventional Java-style function types with multiple arguments, e.g. `(T, U) ⇒ T`; tuple types need to be used instead, e.g. `((T, U)) ⇒ T`
+- Limited support for recursive case classes (including `List`): generated code may fail and, in particular, cannot contain recursive functions. Example that fails to generate sensible code: `T => List[T]` (the generated code always returns empty list)
 
 # Examples of working functionality
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val curryhoward: Project = (project in file("."))
   .settings(common)
   .settings(
     organization := "io.chymyst",
-    version := "0.2.4",
+    version := "0.3.0",
 
     licenses := Seq("Apache License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
     homepage := Some(url("https://github.com/Chymyst/curryhoward")),

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -58,51 +58,7 @@ scala> case class User[N, I](name: N, id: I)
 defined class User
 
 scala> def makeUser[N, I](userName: N, userIdGenerator: N ⇒ I): User[N, I] = implement
-DEBUG: applied rule ->R to sequent [ |- N ⇒ (N ⇒ I) ⇒ User[N,I]], new sequents [N |- (N ⇒ I) ⇒ User[N,I]]
-DEBUG: applied rule ->R to sequent [N |- (N ⇒ I) ⇒ User[N,I]], new sequents [N ⇒ I; N |- User[N,I]]
-DEBUG: applied rule _&R to sequent [N ⇒ I; N |- User[N,I]], new sequents [N ⇒ I; N |- (N, I)]
-DEBUG: applied rule &R to sequent [N ⇒ I; N |- (N, I)], new sequents [N ⇒ I; N |- N]; [N ⇒ I; N |- I]
-DEBUG: sequent [N ⇒ I; N |- N] followsFromAxioms: b ⇒ a ⇒ a
-DEBUG: applied rule ->L1 to sequent [N ⇒ I; N |- N], new sequents [I; N |- N]
-DEBUG: sequent [I; N |- N] followsFromAxioms: b ⇒ a ⇒ a
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ a ,
- for sequent [I; N |- N]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 3 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ a ,
- for sequent [N ⇒ I; N |- N]
-DEBUG: applied rule ->L1 to sequent [N ⇒ I; N |- I], new sequents [I; N |- I]
-DEBUG: sequent [I; N |- I] followsFromAxioms: a ⇒ b ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ a ,
- for sequent [I; N |- I]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ a b ,
- for sequent [N ⇒ I; N |- I]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule &R
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ (a, b a) ,
- for sequent [N ⇒ I; N |- (N, I)]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule _&R
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ User(a, b a) ,
- for sequent [N ⇒ I; N |- User[N,I]]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ User(a, b a) ,
- for sequent [N |- (N ⇒ I) ⇒ User[N,I]]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ User(a, b a) ,
- for sequent [ |- N ⇒ (N ⇒ I) ⇒ User[N,I]]
-DEBUG: for main sequent [ |- N ⇒ (N ⇒ I) ⇒ User[N,I]], obtained 1 final proof terms:
- a ⇒ b ⇒ User(a, b a); score = ((),0,0.0,0.0,1): 0 unused args: Set(); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: Vector() . This took 184 ms
-<console>:17: Returning term: ((\((a:N) ⇒ (b:N ⇒ I) ⇒ User(a, (b a))) userName) userIdGenerator)
-       def makeUser[N, I](userName: N, userIdGenerator: N ⇒ I): User[N, I] = implement
-                                                                             ^
-<console>:17: Returning code: ((a: N) => ((b: _root_.scala.Function1[N, I]) => User[N, I](a, b(a))))(userName)(userIdGenerator)
+<console>:17: Returning term: (a ⇒ b ⇒ User(a, b a)) userName userIdGenerator
        def makeUser[N, I](userName: N, userIdGenerator: N ⇒ I): User[N, I] = implement
                                                                              ^
 makeUser: [N, I](userName: N, userIdGenerator: N => I)User[N,I]
@@ -123,26 +79,7 @@ The `curryhoward` library, of course, works with _curried_ functions as well:
 
 ```scala
 scala> def const[A, B]: A ⇒ B ⇒ A = implement
-DEBUG: applied rule ->R to sequent [ |- A ⇒ B ⇒ A], new sequents [A |- B ⇒ A]
-DEBUG: applied rule ->R to sequent [A |- B ⇒ A], new sequents [B; A |- A]
-DEBUG: sequent [B; A |- A] followsFromAxioms: b ⇒ a ⇒ a
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ a ,
- for sequent [B; A |- A]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ a ,
- for sequent [A |- B ⇒ A]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ a ,
- for sequent [ |- A ⇒ B ⇒ A]
-DEBUG: for main sequent [ |- A ⇒ B ⇒ A], obtained 1 final proof terms:
- a ⇒ b ⇒ a; score = ((),1,0.0,0.0,0): 1 unused args: Set(b); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() . This took 50 ms
-<console>:15: Returning term: \((a:A) ⇒ (b:B) ⇒ a)
-       def const[A, B]: A ⇒ B ⇒ A = implement
-                                    ^
-<console>:15: Returning code: ((a: A) => ((b: B) => a))
+<console>:15: Returning term: a ⇒ b ⇒ a
        def const[A, B]: A ⇒ B ⇒ A = implement
                                     ^
 const: [A, B]=> A => (B => A)
@@ -160,41 +97,7 @@ Here is a more complicated example that automatically implements the `fmap` func
 
 ```scala
 scala> def fmap[E, A, B]: (A ⇒ B) ⇒ (E ⇒ A) ⇒ (E ⇒ B) = implement
-DEBUG: applied rule ->R to sequent [ |- (A ⇒ B) ⇒ (E ⇒ A) ⇒ E ⇒ B], new sequents [A ⇒ B |- (E ⇒ A) ⇒ E ⇒ B]
-DEBUG: applied rule ->R to sequent [A ⇒ B |- (E ⇒ A) ⇒ E ⇒ B], new sequents [E ⇒ A; A ⇒ B |- E ⇒ B]
-DEBUG: applied rule ->R to sequent [E ⇒ A; A ⇒ B |- E ⇒ B], new sequents [E; E ⇒ A; A ⇒ B |- B]
-DEBUG: applied rule ->L1 to sequent [E; E ⇒ A; A ⇒ B |- B], new sequents [A; E; A ⇒ B |- B]
-DEBUG: applied rule ->L1 to sequent [A; E; A ⇒ B |- B], new sequents [B; A; E |- B]
-DEBUG: sequent [B; A; E |- B] followsFromAxioms: a ⇒ b ⇒ c ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ a ,
- for sequent [B; A; E |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 2 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ c ⇒ a ⇒ a b ,
- for sequent [A; E; A ⇒ B |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- c ⇒ b ⇒ a ⇒ a (b c) ,
- for sequent [E; E ⇒ A; A ⇒ B |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ c ⇒ a (b c) ,
- for sequent [E ⇒ A; A ⇒ B |- E ⇒ B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ a (b c) ,
- for sequent [A ⇒ B |- (E ⇒ A) ⇒ E ⇒ B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ a (b c) ,
- for sequent [ |- (A ⇒ B) ⇒ (E ⇒ A) ⇒ E ⇒ B]
-DEBUG: for main sequent [ |- (A ⇒ B) ⇒ (E ⇒ A) ⇒ E ⇒ B], obtained 1 final proof terms:
- a ⇒ b ⇒ c ⇒ a (b c); score = ((),0,0.0,0.0,0): 0 unused args: Set(); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() . This took 79 ms
-<console>:15: Returning term: \((a:A ⇒ B) ⇒ (b:E ⇒ A) ⇒ (c:E) ⇒ (a (b c)))
-       def fmap[E, A, B]: (A ⇒ B) ⇒ (E ⇒ A) ⇒ (E ⇒ B) = implement
-                                                        ^
-<console>:15: Returning code: ((a: _root_.scala.Function1[A, B]) => ((b: _root_.scala.Function1[E, A]) => ((c: E) => a(b(c)))))
+<console>:15: Returning term: a ⇒ b ⇒ c ⇒ a (b c)
        def fmap[E, A, B]: (A ⇒ B) ⇒ (E ⇒ A) ⇒ (E ⇒ B) = implement
                                                         ^
 fmap: [E, A, B]=> (A => B) => ((E => A) => (E => B))
@@ -219,89 +122,7 @@ Here is the applicative `map2` function for the Reader monad:
 
 ```scala
 scala> def map2[E, A, B, C](readerA: E ⇒ A, readerB: E ⇒ B, f: A ⇒ B ⇒ C): E ⇒ C = implement
-DEBUG: applied rule ->R to sequent [ |- (E ⇒ A) ⇒ (E ⇒ B) ⇒ (A ⇒ B ⇒ C) ⇒ E ⇒ C], new sequents [E ⇒ A |- (E ⇒ B) ⇒ (A ⇒ B ⇒ C) ⇒ E ⇒ C]
-DEBUG: applied rule ->R to sequent [E ⇒ A |- (E ⇒ B) ⇒ (A ⇒ B ⇒ C) ⇒ E ⇒ C], new sequents [E ⇒ B; E ⇒ A |- (A ⇒ B ⇒ C) ⇒ E ⇒ C]
-DEBUG: applied rule ->R to sequent [E ⇒ B; E ⇒ A |- (A ⇒ B ⇒ C) ⇒ E ⇒ C], new sequents [A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- E ⇒ C]
-DEBUG: applied rule ->R to sequent [A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- E ⇒ C], new sequents [E; A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- C]
-DEBUG: applied rule ->L1 to sequent [E; A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- C], new sequents [B; E; A ⇒ B ⇒ C; E ⇒ A |- C]
-DEBUG: applied rule ->L1 to sequent [B; E; A ⇒ B ⇒ C; E ⇒ A |- C], new sequents [A; B; E; A ⇒ B ⇒ C |- C]
-DEBUG: applied rule ->L1 to sequent [A; B; E; A ⇒ B ⇒ C |- C], new sequents [B ⇒ C; A; B; E |- C]
-DEBUG: applied rule ->L1 to sequent [B ⇒ C; A; B; E |- C], new sequents [C; A; B; E |- C]
-DEBUG: sequent [C; A; B; E |- C] followsFromAxioms: a ⇒ b ⇒ c ⇒ d ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ d ⇒ a ,
- for sequent [C; A; B; E |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- a ⇒ c ⇒ b ⇒ d ⇒ a b ,
- for sequent [B ⇒ C; A; B; E |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ c ⇒ d ⇒ a ⇒ a b c ,
- for sequent [A; B; E; A ⇒ B ⇒ C |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- d ⇒ c ⇒ a ⇒ b ⇒ a (b c) d ,
- for sequent [B; E; A ⇒ B ⇒ C; E ⇒ A |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: applied rule ->L1 to sequent [E; A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- C], new sequents [A; E; A ⇒ B ⇒ C; E ⇒ B |- C]
-DEBUG: applied rule ->L1 to sequent [A; E; A ⇒ B ⇒ C; E ⇒ B |- C], new sequents [B ⇒ C; A; E; E ⇒ B |- C]
-DEBUG: applied rule ->L1 to sequent [B ⇒ C; A; E; E ⇒ B |- C], new sequents [B; B ⇒ C; A; E |- C]
-DEBUG: applied rule ->L1 to sequent [B; B ⇒ C; A; E |- C], new sequents [C; B; A; E |- C]
-DEBUG: sequent [C; B; A; E |- C] followsFromAxioms: a ⇒ b ⇒ c ⇒ d ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ d ⇒ a ,
- for sequent [C; B; A; E |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ c ⇒ d ⇒ a b ,
- for sequent [B; B ⇒ C; A; E |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- a ⇒ d ⇒ c ⇒ b ⇒ a (b c) ,
- for sequent [B ⇒ C; A; E; E ⇒ B |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: applied rule ->L1 to sequent [A; E; A ⇒ B ⇒ C; E ⇒ B |- C], new sequents [B; A; E; A ⇒ B ⇒ C |- C]
-DEBUG: applied rule ->L1 to sequent [B; A; E; A ⇒ B ⇒ C |- C], new sequents [B ⇒ C; B; A; E |- C]
-DEBUG: applied rule ->L1 to sequent [B ⇒ C; B; A; E |- C], new sequents [C; B; A; E |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ d ⇒ a b ,
- for sequent [B ⇒ C; B; A; E |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- c ⇒ b ⇒ d ⇒ a ⇒ a b c ,
- for sequent [B; A; E; A ⇒ B ⇒ C |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ d ⇒ a ⇒ c ⇒ a b (c d) ,
- for sequent [A; E; A ⇒ B ⇒ C; E ⇒ B |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- c ⇒ a ⇒ d ⇒ b ⇒ a (b c) (d c) ,
- for sequent [E; A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ d ⇒ b ⇒ c ⇒ a (b c) (d c) ,
- for sequent [A ⇒ B ⇒ C; E ⇒ B; E ⇒ A |- E ⇒ C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- d ⇒ b ⇒ a ⇒ c ⇒ a (b c) (d c) ,
- for sequent [E ⇒ B; E ⇒ A |- (A ⇒ B ⇒ C) ⇒ E ⇒ C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- b ⇒ d ⇒ a ⇒ c ⇒ a (b c) (d c) ,
- for sequent [E ⇒ A |- (E ⇒ B) ⇒ (A ⇒ B ⇒ C) ⇒ E ⇒ C]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- b ⇒ d ⇒ a ⇒ c ⇒ a (b c) (d c) ,
- for sequent [ |- (E ⇒ A) ⇒ (E ⇒ B) ⇒ (A ⇒ B ⇒ C) ⇒ E ⇒ C]
-DEBUG: for main sequent [ |- (E ⇒ A) ⇒ (E ⇒ B) ⇒ (A ⇒ B ⇒ C) ⇒ E ⇒ C], obtained 1 final proof terms:
- b ⇒ d ⇒ a ⇒ c ⇒ a (b c) (d c); score = ((),0,0.0,0.0,1): 0 unused args: Set(); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() . This took 88 ms
-<console>:15: Returning term: (((\((b:E ⇒ A) ⇒ (d:E ⇒ B) ⇒ (a:A ⇒ B ⇒ C) ⇒ (c:E) ⇒ ((a (b c)) (d c))) readerA) readerB) f)
-       def map2[E, A, B, C](readerA: E ⇒ A, readerB: E ⇒ B, f: A ⇒ B ⇒ C): E ⇒ C = implement
-                                                                                   ^
-<console>:15: Returning code: ((b: _root_.scala.Function1[E, A]) => ((d: _root_.scala.Function1[E, B]) => ((a: _root_.scala.Function1[A, _root_.scala.Function1[B, C]]) => ((c: E) => a(b(c))(d(c))))))(readerA)(readerB)(f)
+<console>:15: Returning term: (b ⇒ d ⇒ a ⇒ c ⇒ a (b c) (d c)) readerA readerB f
        def map2[E, A, B, C](readerA: E ⇒ A, readerB: E ⇒ B, f: A ⇒ B ⇒ C): E ⇒ C = implement
                                                                                    ^
 map2: [E, A, B, C](readerA: E => A, readerB: E => B, f: A => (B => C))E => C
@@ -331,51 +152,7 @@ we now write
 
 ```scala
 scala> ofType[User[Int, String]](123, (n: Int) ⇒ "id:" + (n * 100).toString)
-DEBUG: applied rule ->R to sequent [ |- <c>Int ⇒ (<c>Int ⇒ <c>String) ⇒ User[<c>Int,<c>String]], new sequents [<c>Int |- (<c>Int ⇒ <c>String) ⇒ User[<c>Int,<c>String]]
-DEBUG: applied rule ->R to sequent [<c>Int |- (<c>Int ⇒ <c>String) ⇒ User[<c>Int,<c>String]], new sequents [<c>Int ⇒ <c>String; <c>Int |- User[<c>Int,<c>String]]
-DEBUG: applied rule _&R to sequent [<c>Int ⇒ <c>String; <c>Int |- User[<c>Int,<c>String]], new sequents [<c>Int ⇒ <c>String; <c>Int |- (<c>Int, <c>String)]
-DEBUG: applied rule &R to sequent [<c>Int ⇒ <c>String; <c>Int |- (<c>Int, <c>String)], new sequents [<c>Int ⇒ <c>String; <c>Int |- <c>Int]; [<c>Int ⇒ <c>String; <c>Int |- <c>String]
-DEBUG: sequent [<c>Int ⇒ <c>String; <c>Int |- <c>Int] followsFromAxioms: b ⇒ a ⇒ a
-DEBUG: applied rule ->L1 to sequent [<c>Int ⇒ <c>String; <c>Int |- <c>Int], new sequents [<c>String; <c>Int |- <c>Int]
-DEBUG: sequent [<c>String; <c>Int |- <c>Int] followsFromAxioms: b ⇒ a ⇒ a
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ a ,
- for sequent [<c>String; <c>Int |- <c>Int]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ a ,
- for sequent [<c>Int ⇒ <c>String; <c>Int |- <c>Int]
-DEBUG: applied rule ->L1 to sequent [<c>Int ⇒ <c>String; <c>Int |- <c>String], new sequents [<c>String; <c>Int |- <c>String]
-DEBUG: sequent [<c>String; <c>Int |- <c>String] followsFromAxioms: a ⇒ b ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ a ,
- for sequent [<c>String; <c>Int |- <c>String]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ a b ,
- for sequent [<c>Int ⇒ <c>String; <c>Int |- <c>String]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule &R
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ (a, b a) ,
- for sequent [<c>Int ⇒ <c>String; <c>Int |- (<c>Int, <c>String)]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 1 terms out of 1 back-transformed terms; after rule _&R
-DEBUG: returning 1 terms:
- b ⇒ a ⇒ User(a, b a) ,
- for sequent [<c>Int ⇒ <c>String; <c>Int |- User[<c>Int,<c>String]]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ User(a, b a) ,
- for sequent [<c>Int |- (<c>Int ⇒ <c>String) ⇒ User[<c>Int,<c>String]]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->R
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ User(a, b a) ,
- for sequent [ |- <c>Int ⇒ (<c>Int ⇒ <c>String) ⇒ User[<c>Int,<c>String]]
-DEBUG: for main sequent [ |- <c>Int ⇒ (<c>Int ⇒ <c>String) ⇒ User[<c>Int,<c>String]], obtained 1 final proof terms:
- a ⇒ b ⇒ User(a, b a); score = ((),0,0.0,0.0,1): 0 unused args: Set(); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: Vector() . This took 107 ms
-<console>:18: Returning term: ((\((a:<c>Int) ⇒ (b:<c>Int ⇒ <c>String) ⇒ User(a, (b a))) arg1) arg2)
-       ofType[User[Int, String]](123, (n: Int) ⇒ "id:" + (n * 100).toString)
-                                ^
-<console>:18: Returning code: ((a: Int) => ((b: _root_.scala.Function1[Int, String]) => User[Int, String](a, b(a))))(123)(((n: scala.Int) => "id:".+(n.*(100).toString())))
+<console>:18: Returning term: (a ⇒ b ⇒ User(a, b a)) arg1 arg2
        ofType[User[Int, String]](123, (n: Int) ⇒ "id:" + (n * 100).toString)
                                 ^
 res3: User[Int,String] = User(123,id:12300)
@@ -389,11 +166,6 @@ The macro `ofType()` will not work without specifying a type expression as its t
 
 ```scala
 scala> val x: Int = ofType(123)
-DEBUG: applied rule ->R to sequent [ |- <c>Int ⇒ 0], new sequents [<c>Int |- 0]
-DEBUG: returning no terms for sequent [<c>Int |- 0]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 2 ms and produced 0 terms out of 0 back-transformed terms; after rule ->R
-DEBUG: returning no terms for sequent [ |- <c>Int ⇒ 0]
-DEBUG: for main sequent [ |- <c>Int ⇒ 0], obtained no final proof terms. This took 37 ms
 <console>:15: error: type <c>Int ⇒ 0 cannot be implemented
        val x: Int = ofType(123)
                           ^
@@ -451,87 +223,12 @@ As an example, consider the `map` function for the State monad:
 
 ```scala
 scala> def map[S, A, B]: (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ (S ⇒ (B, S)) = implement
-DEBUG: applied rule ->R to sequent [ |- (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ S ⇒ (B, S)], new sequents [S ⇒ (A, S) |- (A ⇒ B) ⇒ S ⇒ (B, S)]
-DEBUG: applied rule ->R to sequent [S ⇒ (A, S) |- (A ⇒ B) ⇒ S ⇒ (B, S)], new sequents [A ⇒ B; S ⇒ (A, S) |- S ⇒ (B, S)]
-DEBUG: applied rule ->R to sequent [A ⇒ B; S ⇒ (A, S) |- S ⇒ (B, S)], new sequents [S; A ⇒ B; S ⇒ (A, S) |- (B, S)]
-DEBUG: applied rule &R to sequent [S; A ⇒ B; S ⇒ (A, S) |- (B, S)], new sequents [S; A ⇒ B; S ⇒ (A, S) |- B]; [S; A ⇒ B; S ⇒ (A, S) |- S]
-DEBUG: applied rule ->L1 to sequent [S; A ⇒ B; S ⇒ (A, S) |- B], new sequents [(A, S); S; A ⇒ B |- B]
-DEBUG: applied rule &L to sequent [(A, S); S; A ⇒ B |- B], new sequents [A; S; S; A ⇒ B |- B]
-DEBUG: applied rule ->L1 to sequent [A; S; S; A ⇒ B |- B], new sequents [B; A; S; S |- B]
-DEBUG: sequent [B; A; S; S |- B] followsFromAxioms: a ⇒ b ⇒ c ⇒ d ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ d ⇒ a ,
- for sequent [B; A; S; S |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- b ⇒ c ⇒ d ⇒ a ⇒ a b ,
- for sequent [A; S; S; A ⇒ B |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule &L
-DEBUG: returning 1 terms:
- b ⇒ c ⇒ a ⇒ a b._1 ,
- for sequent [(A, S); S; A ⇒ B |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 1 terms:
- c ⇒ a ⇒ b ⇒ a b c._1 ,
- for sequent [S; A ⇒ B; S ⇒ (A, S) |- B]
-DEBUG: sequent [S; A ⇒ B; S ⇒ (A, S) |- S] followsFromAxioms: a ⇒ b ⇒ c ⇒ a
-DEBUG: applied rule ->L1 to sequent [S; A ⇒ B; S ⇒ (A, S) |- S], new sequents [(A, S); S; A ⇒ B |- S]
-DEBUG: sequent [(A, S); S; A ⇒ B |- S] followsFromAxioms: b ⇒ a ⇒ c ⇒ a
-DEBUG: applied rule &L to sequent [(A, S); S; A ⇒ B |- S], new sequents [A; S; S; A ⇒ B |- S]
-DEBUG: sequent [A; S; S; A ⇒ B |- S] followsFromAxioms: b ⇒ a ⇒ c ⇒ d ⇒ a; b ⇒ c ⇒ a ⇒ d ⇒ a
-DEBUG: applied rule ->L1 to sequent [A; S; S; A ⇒ B |- S], new sequents [B; A; S; S |- S]
-DEBUG: sequent [B; A; S; S |- S] followsFromAxioms: b ⇒ c ⇒ a ⇒ d ⇒ a; b ⇒ c ⇒ d ⇒ a ⇒ a
-DEBUG: returning 2 terms:
- b ⇒ c ⇒ a ⇒ d ⇒ a ;
- b ⇒ c ⇒ d ⇒ a ⇒ a ,
- for sequent [B; A; S; S |- S]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 6 ms and produced 2 terms out of 2 back-transformed terms; after rule ->L1
-DEBUG: returning 2 terms:
- b ⇒ a ⇒ c ⇒ d ⇒ a ;
- b ⇒ c ⇒ a ⇒ d ⇒ a ,
- for sequent [A; S; S; A ⇒ B |- S]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 2 ms and produced 2 terms out of 2 back-transformed terms; after rule &L
-DEBUG: returning 2 terms:
- b ⇒ a ⇒ c ⇒ a ;
- a ⇒ b ⇒ c ⇒ a._2 ,
- for sequent [(A, S); S; A ⇒ B |- S]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 2 terms out of 2 back-transformed terms; after rule ->L1
-DEBUG: returning 2 terms:
- b ⇒ c ⇒ a ⇒ a b._2 ;
- a ⇒ b ⇒ c ⇒ a ,
- for sequent [S; A ⇒ B; S ⇒ (A, S) |- S]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 7 ms and produced 2 terms out of 2 back-transformed terms; after rule &R
-DEBUG: returning 2 terms:
- c ⇒ a ⇒ b ⇒ (a b c._1, b c._2) ;
- c ⇒ a ⇒ b ⇒ (a b c._1, c) ,
- for sequent [S; A ⇒ B; S ⇒ (A, S) |- (B, S)]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- a ⇒ b ⇒ c ⇒ (a b c._1, b c._2) ;
- a ⇒ b ⇒ c ⇒ (a b c._1, c) ,
- for sequent [A ⇒ B; S ⇒ (A, S) |- S ⇒ (B, S)]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- b ⇒ a ⇒ c ⇒ (a b c._1, b c._2) ;
- b ⇒ a ⇒ c ⇒ (a b c._1, c) ,
- for sequent [S ⇒ (A, S) |- (A ⇒ B) ⇒ S ⇒ (B, S)]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- b ⇒ a ⇒ c ⇒ (a b c._1, b c._2) ;
- b ⇒ a ⇒ c ⇒ (a b c._1, c) ,
- for sequent [ |- (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ S ⇒ (B, S)]
-DEBUG: for main sequent [ |- (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ S ⇒ (B, S)], obtained 2 final proof terms:
- b ⇒ a ⇒ c ⇒ (a b c._1, b c._2); score = ((),0,0.0,0.0,2): 0 unused args: Set(); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List((a b,1), (a b,2)) ;
- b ⇒ a ⇒ c ⇒ (a b c._1, c); score = ((),0,1.0,0.0,1): 0 unused args: Set(); unusedMatchClauseVars=0.0; unusedTupleParts=1; used tuple parts: List((a b,1)) . This took 102 ms
 <console>:15: warning: type (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ S ⇒ (B, S) has 2 implementations (laws need checking?):
  b ⇒ a ⇒ c ⇒ (a b c._1, b c._2) [score: ((),0,0.0,0.0,2)];
  b ⇒ a ⇒ c ⇒ (a b c._1, c) [score: ((),0,1.0,0.0,1)].
        def map[S, A, B]: (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ (S ⇒ (B, S)) = implement
                                                                  ^
-<console>:15: Returning term: \((b:S ⇒ (A, S)) ⇒ (a:A ⇒ B) ⇒ (c:S) ⇒ ((a (b c)._1), (b c)._2))
-       def map[S, A, B]: (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ (S ⇒ (B, S)) = implement
-                                                                 ^
-<console>:15: Returning code: ((b: _root_.scala.Function1[S, scala.Tuple2[A, S]]) => ((a: _root_.scala.Function1[A, B]) => ((c: S) => scala.Tuple2(a(b(c)._1), b(c)._2))))
+<console>:15: Returning term: b ⇒ a ⇒ c ⇒ (a b c._1, b c._2)
        def map[S, A, B]: (S ⇒ (A, S)) ⇒ (A ⇒ B) ⇒ (S ⇒ (B, S)) = implement
                                                                  ^
 map: [S, A, B]=> (S => (A, S)) => ((A => B) => (S => (B, S)))
@@ -553,39 +250,6 @@ If there are several such implementations, no sensible choice is possible, and t
 
 ```scala
 scala> def ff[A, B]: A ⇒ A ⇒ (A ⇒ B) ⇒ B = implement
-DEBUG: applied rule ->R to sequent [ |- A ⇒ A ⇒ (A ⇒ B) ⇒ B], new sequents [A |- A ⇒ (A ⇒ B) ⇒ B]
-DEBUG: applied rule ->R to sequent [A |- A ⇒ (A ⇒ B) ⇒ B], new sequents [A; A |- (A ⇒ B) ⇒ B]
-DEBUG: applied rule ->R to sequent [A; A |- (A ⇒ B) ⇒ B], new sequents [A ⇒ B; A; A |- B]
-DEBUG: applied rule ->L1 to sequent [A ⇒ B; A; A |- B], new sequents [B; A; A |- B]
-DEBUG: sequent [B; A; A |- B] followsFromAxioms: a ⇒ b ⇒ c ⇒ a
-DEBUG: returning 1 terms:
- a ⇒ b ⇒ c ⇒ a ,
- for sequent [B; A; A |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 2 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: applied rule ->L1 to sequent [A ⇒ B; A; A |- B], new sequents [B; A; A |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 1 terms out of 1 back-transformed terms; after rule ->L1
-DEBUG: returning 2 terms:
- a ⇒ b ⇒ c ⇒ a b ;
- a ⇒ c ⇒ b ⇒ a b ,
- for sequent [A ⇒ B; A; A |- B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 4 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- b ⇒ c ⇒ a ⇒ a b ;
- c ⇒ b ⇒ a ⇒ a b ,
- for sequent [A; A |- (A ⇒ B) ⇒ B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- c ⇒ b ⇒ a ⇒ a b ;
- b ⇒ c ⇒ a ⇒ a b ,
- for sequent [A |- A ⇒ (A ⇒ B) ⇒ B]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 0 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- c ⇒ b ⇒ a ⇒ a b ;
- b ⇒ c ⇒ a ⇒ a b ,
- for sequent [ |- A ⇒ A ⇒ (A ⇒ B) ⇒ B]
-DEBUG: for main sequent [ |- A ⇒ A ⇒ (A ⇒ B) ⇒ B], obtained 2 final proof terms:
- c ⇒ b ⇒ a ⇒ a b; score = ((),1,0.0,0.0,0): 1 unused args: Set(c); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() ;
- b ⇒ c ⇒ a ⇒ a b; score = ((),1,0.0,0.0,0): 1 unused args: Set(c); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() . This took 71 ms
 <console>:15: error: type A ⇒ A ⇒ (A ⇒ B) ⇒ B can be implemented in 2 inequivalent ways:
  c ⇒ b ⇒ a ⇒ a b [score: ((),1,0.0,0.0,0)];
  b ⇒ c ⇒ a ⇒ a b [score: ((),1,0.0,0.0,0)].
@@ -604,36 +268,10 @@ As a simple example, consider a function of type `Int ⇒ Int ⇒ Int`:
 
 ```scala
 scala> val fs = allOfType[Int ⇒ Int ⇒ Int]
-DEBUG: applied rule ->R to sequent [ |- <c>Int ⇒ <c>Int ⇒ <c>Int], new sequents [<c>Int |- <c>Int ⇒ <c>Int]
-DEBUG: applied rule ->R to sequent [<c>Int |- <c>Int ⇒ <c>Int], new sequents [<c>Int; <c>Int |- <c>Int]
-DEBUG: sequent [<c>Int; <c>Int |- <c>Int] followsFromAxioms: a ⇒ b ⇒ a; b ⇒ a ⇒ a
-DEBUG: returning 2 terms:
- a ⇒ b ⇒ a ;
- b ⇒ a ⇒ a ,
- for sequent [<c>Int; <c>Int |- <c>Int]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 16 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- b ⇒ a ⇒ a ;
- a ⇒ b ⇒ a ,
- for sequent [<c>Int |- <c>Int ⇒ <c>Int]
-DEBUG: transformedProofs.map(_.simplify()).distinct took 1 ms and produced 2 terms out of 2 back-transformed terms; after rule ->R
-DEBUG: returning 2 terms:
- b ⇒ a ⇒ a ;
- a ⇒ b ⇒ a ,
- for sequent [ |- <c>Int ⇒ <c>Int ⇒ <c>Int]
-DEBUG: for main sequent [ |- <c>Int ⇒ <c>Int ⇒ <c>Int], obtained 2 final proof terms:
- b ⇒ a ⇒ a; score = ((),1,0.0,0.0,0): 1 unused args: Set(b); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() ;
- a ⇒ b ⇒ a; score = ((),1,0.0,0.0,0): 1 unused args: Set(b); unusedMatchClauseVars=0.0; unusedTupleParts=0; used tuple parts: List() . This took 75 ms
-<console>:15: Returning term: \((b:<c>Int) ⇒ (a:<c>Int) ⇒ a)
+<console>:15: Returning term: b ⇒ a ⇒ a
        val fs = allOfType[Int ⇒ Int ⇒ Int]
                          ^
-<console>:15: Returning code: ((b: Int) => ((a: Int) => a))
-       val fs = allOfType[Int ⇒ Int ⇒ Int]
-                         ^
-<console>:15: Returning term: \((a:<c>Int) ⇒ (b:<c>Int) ⇒ a)
-       val fs = allOfType[Int ⇒ Int ⇒ Int]
-                         ^
-<console>:15: Returning code: ((a: Int) => ((b: Int) => a))
+<console>:15: Returning term: a ⇒ b ⇒ a
        val fs = allOfType[Int ⇒ Int ⇒ Int]
                          ^
 fs: Seq[Int => (Int => Int)] = List(<function1>, <function1>)

--- a/src/main/scala/io/chymyst/ch/LJT.scala
+++ b/src/main/scala/io/chymyst/ch/LJT.scala
@@ -50,7 +50,7 @@ Additional rules for named conjunctions:
 
 + G* |- Named(A, B) when G* |- (A & B)  -- rule _&R
 + G*, Named(A, B) |- C when G*, (A & B) |- C  -- rule _&L
-+ G*, Named(A, B) ⇒ C |- D when G*, (A & B) ⇒ C |- D  -- rule _->L
++ G*, Named(A, B) ⇒ C |- D when G*, (A & B) ⇒ C |- D  -- rule _->L2
  */
 
 object LJT {
@@ -305,8 +305,8 @@ object LJT {
       })
   }
 
-  // G*, Named(A, B) ⇒ C |- D when G*, (A & B) ⇒ C |- D  -- rule _->L
-  private def ruleImplicationWithNamedConjunctionAtLeft[T] = uniformRule[T]("_->L") {
+  // G*, Named(A, B) ⇒ C |- D when G*, (A & B) ⇒ C |- D  -- rule _->L2
+  private def ruleImplicationWithNamedConjunctionAtLeft[T] = uniformRule[T]("_->L2") {
     case (nct@NamedConjunctT(constructor, _, accessors, wrapped)) #-> argC ⇒
       val unwrapped = ConjunctT(wrapped match {
         case Nil ⇒ // empty wrapper means a named Unit as a case object

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -182,6 +182,7 @@ class Macros(val c: whitebox.Context) {
     }
 
     typeExpr match {
+      // TODO: check whether `head` is a ConjunctT, then reify as FunctionN[].
       case head #-> body ⇒ tq"(${reifyType(head)}) ⇒ ${reifyType(body)}"
       case TP(nameT) ⇒ makeTypeName(nameT)
       case BasicT(nameT) ⇒ makeTypeName(nameT)
@@ -257,7 +258,7 @@ class Macros(val c: whitebox.Context) {
         heads.reverse.foldLeft(reifyTermShort(replacedBody)) { case (prevTree, paramE) ⇒
           conjunctHeads.find(_._1 == paramE) match {
             case Some((_, terms)) ⇒
-              q"((..${terms.zipWithIndex.map { case (t, i) ⇒ reifyParam(PropE(conjunctSubstName(paramE, i), t))}}) ⇒ $prevTree)"
+              q"((..${terms.zipWithIndex.map { case (t, i) ⇒ reifyParam(PropE(conjunctSubstName(paramE, i), t)) }}) ⇒ $prevTree)"
             case None ⇒ q"(${reifyParam(paramE)} ⇒ $prevTree)"
           }
         }

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -182,7 +182,8 @@ class Macros(val c: whitebox.Context) {
     }
 
     typeExpr match {
-      // TODO: check whether `head` is a ConjunctT, then reify as FunctionN[].
+      // Special case for Java-style arg lists.
+      case ConjunctT(terms) #-> body ⇒ tq"(..${terms.map(reifyType)}) ⇒ ${reifyType(body)}"
       case head #-> body ⇒ tq"(${reifyType(head)}) ⇒ ${reifyType(body)}"
       case TP(nameT) ⇒ makeTypeName(nameT)
       case BasicT(nameT) ⇒ makeTypeName(nameT)

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -251,8 +251,9 @@ class Macros(val c: whitebox.Context) {
             p,
             ConjunctE(termTypes.zipWithIndex.map { case (t, i) ⇒ PropE(conjunctSubstName(p, i), t) }),
             prev
-          )
-        }
+          ).simplify()
+        }.simplify(withEta = true)
+
         heads.reverse.foldLeft(reifyTermShort(replacedBody)) { case (prevTree, paramE) ⇒
           conjunctHeads.find(_._1 == paramE) match {
             case Some((_, terms)) ⇒

--- a/src/main/scala/io/chymyst/ch/TypeExpr.scala
+++ b/src/main/scala/io/chymyst/ch/TypeExpr.scala
@@ -12,7 +12,7 @@ sealed trait TypeExpr[+T] {
     case BasicT(name) ⇒ s"<c>$name" // well-known constant type such as Int
     case ConstructorT(fullExpr) ⇒ s"<tc>$fullExpr" // type constructor with arguments, such as Seq[Int]
     case TP(name) ⇒ s"$name"
-    case NamedConjunctT(constructor, tParams, _, wrapped) ⇒
+    case NamedConjunctT(constructor, tParams, _, wrapped@_) ⇒
       //      val termString = "(" + wrapped.map(_.prettyPrint).mkString(",") + ")" // Too verbose.
       val typeSuffix = if (caseObjectName.isDefined) ".type" else ""
       s"$constructor${TypeExpr.tParamString(tParams)}$typeSuffix"

--- a/src/test/scala/io/chymyst/ch/unit/LJTSpec2.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LJTSpec2.scala
@@ -263,4 +263,19 @@ class LJTSpec2 extends FlatSpec with Matchers {
 
   }
 
+  it should "check example from chapter 4 problem 6" in {
+    sealed trait Result[A, B]
+    case class P[A, B](a: A, b: B, c: Int) extends Result[A, B]
+    case class Q[A, B](d: Int ⇒ A, e: Int ⇒ B) extends Result[A, B]
+    case class R[A, B](f: A ⇒ A, g: A ⇒ B) extends Result[A, B]
+
+    // Result[A, B] is a functor in B but not in A.
+    def allFmaps[A, B, C] = allOfType[(B ⇒ C) ⇒ Result[A, B] ⇒ Result[A, C]]
+
+    allFmaps[Int, String, Boolean].length shouldEqual 2
+
+    def allFmapsA[A, B, C] = allOfType[(A ⇒ C) ⇒ Result[A, B] ⇒ Result[C, B]]
+
+    allFmapsA[Int, String, Boolean].length shouldEqual 0
+  }
 }

--- a/src/test/scala/io/chymyst/ch/unit/MatchTypeSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/MatchTypeSpec.scala
@@ -16,7 +16,7 @@ class MatchTypeSpec extends FlatSpec with Matchers {
   it should "get printable representation of enclosing owner's type" in {
     def result[A, B, C]: (String, String) = testType[Int]
 
-    result._2 shouldEqual "(<c>String, <c>String)"
+    result._2 shouldEqual "Tuple2[<c>String,<c>String]"
   }
 
   it should "get printable representation of enclosing owner's type with function syntax" in {
@@ -79,13 +79,13 @@ class MatchTypeSpec extends FlatSpec with Matchers {
   it should "get printable representation of tuple types" in {
     def result[A, B, C]: (String, String) = testType[(Any, Nothing, Unit, A, B, C)]
 
-    result._1 shouldEqual "(<c>_, 0, Unit, A, B, C)"
+    result._1 shouldEqual "Tuple6[<c>_,0,Unit,A,B,C]"
   }
 
   it should "get printable representation of tuple as function argument" in {
     def result[A, B, C]: (String, String) = testType[((A, B)) ⇒ C]
 
-    result._1 shouldEqual "(A, B) ⇒ C"
+    result._1 shouldEqual "Tuple2[A,B] ⇒ C"
   }
 
   val basicTypes = List("Int", "String", "Boolean", "Float", "Double", "Long", "Symbol", "Char")
@@ -93,7 +93,7 @@ class MatchTypeSpec extends FlatSpec with Matchers {
   it should "get printable representation of tuple of basic types" in {
     def result[A, B, C]: (String, String) = testType[(Int, String, Boolean, Float, Double, Long, Symbol, Char)]
 
-    result._1 shouldEqual "(" + basicTypes.map("<c>" + _).mkString(", ") + ")"
+    result._1 shouldEqual "Tuple" + basicTypes.length + "[" + basicTypes.map("<c>" + _).mkString(",") + "]"
   }
 
   it should "get printable representation of single case class" in {

--- a/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
@@ -40,4 +40,21 @@ class OrderingSpec extends FlatSpec with Matchers {
 
     def f2[T](x: Option[Option[T]]): Option[Option[T]] = implement
   }
+
+  behavior of "java arg groups"
+
+  it should "generate identity function for tuples" in {
+    def f1: (Int, String) ⇒ (Int, String) = implement
+
+    f1(1, "abc") shouldEqual ((1, "abc"))
+
+    val Seq(f2a, f2b) = allOfType[ (Int, Int) ⇒ (Int, Int) ]
+
+    f2a(1, 2) shouldEqual ((1, 2))
+    f2b(1, 2) shouldEqual ((2, 1))
+  }
+
+  it should "correctly handle higher-order functions with java arg groups" in {
+    def fmap1[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement
+  }
 }

--- a/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
@@ -77,4 +77,12 @@ class OrderingSpec extends FlatSpec with Matchers {
 
     def fmap4[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement
   }
+
+  it should "handle given values with java arg groups" in {
+    def f(x: String, y: Int): Boolean = y.toString == x
+    val b1 = ofType[Boolean](f _, "abc", 123)
+    b1 shouldEqual false
+    val b2 = ofType[Boolean](f _, "123", 123)
+    b2 shouldEqual true
+  }
 }

--- a/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
@@ -48,7 +48,7 @@ class OrderingSpec extends FlatSpec with Matchers {
 
     f1(1, "abc") shouldEqual ((1, "abc"))
 
-    val Seq(f2a, f2b) = allOfType[ (Int, Int) ⇒ (Int, Int) ]
+    val Seq(f2a, f2b) = allOfType[(Int, Int) ⇒ (Int, Int)]
 
     f2a(1, 2) shouldEqual ((1, 2))
     f2b(1, 2) shouldEqual ((2, 1))
@@ -61,8 +61,20 @@ class OrderingSpec extends FlatSpec with Matchers {
   }
 
   it should "correctly handle higher-order functions with java arg groups" in {
-    def fmap2[A, B]: ((A, Int) ⇒ B) ⇒ A ⇒ Int ⇒ B = implement
+    def fmap1[A, B]: ((A, Int) ⇒ B) ⇒ A ⇒ Int ⇒ B = implement
 
-   "def fmap3[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement" shouldNot compile
+    def f(x: String, y: Int): Boolean = y.toString == x
+
+    fmap1[String, Boolean](f)("123")(123) shouldEqual true
+
+    def fmap2[A, B]: (((A, Int) ⇒ B), A, Int) ⇒ B = implement
+
+    fmap2[String, Boolean](f, "123", 123) shouldEqual true
+
+    def fmap3[A, B](f: (A, Int) ⇒ B, x: A, y: Int): B = implement
+
+    fmap3[String, Boolean](f, "123", 123) shouldEqual true
+
+    def fmap4[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement
   }
 }

--- a/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
@@ -54,6 +54,10 @@ class OrderingSpec extends FlatSpec with Matchers {
     f2b(1, 2) shouldEqual ((2, 1))
   }
 
+  it should "handle function argumens" in {
+    def fmap1[A, B]: (A ⇒ B, (A, Int)) ⇒ (B, Int) = implement
+  }
+
   it should "correctly handle higher-order functions with java arg groups" in {
     def fmap1[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement
   }

--- a/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/OrderingSpec.scala
@@ -56,9 +56,13 @@ class OrderingSpec extends FlatSpec with Matchers {
 
   it should "handle function argumens" in {
     def fmap1[A, B]: (A ⇒ B, (A, Int)) ⇒ (B, Int) = implement
+
+    fmap1[String, Boolean](_ != "abc", ("xyz", 123)) shouldEqual ((true, 123))
   }
 
   it should "correctly handle higher-order functions with java arg groups" in {
-    def fmap1[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement
+    def fmap2[A, B]: ((A, Int) ⇒ B) ⇒ A ⇒ Int ⇒ B = implement
+
+   "def fmap3[A, B]: (A ⇒ B, ((A, Int) ⇒ String) ⇒ Double) ⇒ ((B, Int) ⇒ String) ⇒ Double = implement" shouldNot compile
   }
 }


### PR DESCRIPTION
- [x] support Java-style argument groups in type expressions
- [x] correct pretty-printing for those
- [x] code generation to apply functions to argument groups
- [ ] code generation  to generate argument groups for new lambdas
- [ ] streamline LJT calculus to avoid passing through `ConjunctT` every time