### PR TITLE
omit lambda-terms when using `implement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ For a good overview of approaches to IPL theorem proving, see these talk slides:
 # Known bugs
 
 - Limited support for recursive case classes (including `List`): generated code may fail and, in particular, cannot contain recursive functions. Example that fails to generate sensible code: `T => List[T]` (the generated code always returns empty list)
+- Functions with zero arguments are currently not supported, e.g. `ofType[Int => () => Int]` will not compile
 
 # Examples of working functionality
 

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -183,7 +183,7 @@ class Macros(val c: whitebox.Context) {
     }
 
     implicit def liftedTermExpr: Liftable[TermExpr] = Liftable[TermExpr] {
-      case PropE(name, tExpr) ⇒ q"_root_.io.chymyst.ch.PropE($name, $tExpr)"
+      case VarE(name, tExpr) ⇒ q"_root_.io.chymyst.ch.VarE($name, $tExpr)"
       case AppE(head, arg) ⇒ q"_root_.io.chymyst.ch.AppE($head, $arg)"
       case CurriedE(heads, body) ⇒ q"_root_.io.chymyst.ch.CurriedE(List(..$heads), $body)"
       case UnitE(tExpr) ⇒ q"_root_.io.chymyst.ch.UnitE($tExpr)"
@@ -250,22 +250,22 @@ class Macros(val c: whitebox.Context) {
   }
 
   // Prepare the tree for a function parameter with the specified type.
-  private def reifyParam(term: PropE): c.Tree = term match {
-    case PropE(name, typeExpr) ⇒
+  private def reifyParam(term: VarE): c.Tree = term match {
+    case VarE(name, typeExpr) ⇒
       val tpt = reifyType(typeExpr)
       val termName = TermName(name.toString)
       val param = q"val $termName: $tpt"
       param
   }
 
-  private def reifyTerm(termExpr: TermExpr, givenArgs: Map[PropE, c.Tree]): c.Tree = {
+  private def reifyTerm(termExpr: TermExpr, givenArgs: Map[VarE, c.Tree]): c.Tree = {
     // Shortcut for calling this function recursively with all the same arguments.
     def reifyTermShort(termExpr: TermExpr): c.Tree = reifyTerm(termExpr, givenArgs)
 
-    def conjunctSubstName(p: PropE, i: Int): String = s"${p.name}_$i"
+    def conjunctSubstName(p: VarE, i: Int): String = s"${p.name}_$i"
 
     termExpr match {
-      case p@PropE(name, _) ⇒ givenArgs.getOrElse(p, q"${TermName(name.toString)}")
+      case p@VarE(name, _) ⇒ givenArgs.getOrElse(p, q"${TermName(name.toString)}")
 
       // A function applied to several arguments Java-style.
       case AppE(head, ConjunctE(terms)) ⇒ q"${reifyTermShort(head)}(..${terms.map(reifyTermShort)})"
@@ -276,11 +276,11 @@ class Macros(val c: whitebox.Context) {
       case CurriedE(heads, body) ⇒
         // If one of the heads is a ConjunctT, we need to do a replacement in the entire body.
         // It will be too late to do this once we start reifying the terms.
-        val conjunctHeads = heads.collect { case p@PropE(_, ConjunctT(terms)) ⇒ (p, terms) }
+        val conjunctHeads = heads.collect { case p@VarE(_, ConjunctT(terms)) ⇒ (p, terms) }
         val replacedBody = conjunctHeads.foldLeft(body) {
           case (prev, (p, termTypes)) ⇒ TermExpr.subst(
             p,
-            ConjunctE(termTypes.zipWithIndex.map { case (t, i) ⇒ PropE(conjunctSubstName(p, i), t) }),
+            ConjunctE(termTypes.zipWithIndex.map { case (t, i) ⇒ VarE(conjunctSubstName(p, i), t) }),
             prev
           ).simplify()
         }.simplify(withEta = true)
@@ -289,7 +289,7 @@ class Macros(val c: whitebox.Context) {
         heads.reverse.foldLeft(reifyTermShort(replacedBody)) { case (prevTree, paramE) ⇒
           conjunctHeads.find(_._1 == paramE) match {
             case Some((_, terms)) ⇒
-              val args = terms.zipWithIndex.map { case (t, i) ⇒ reifyParam(PropE(conjunctSubstName(paramE, i), t)) }
+              val args = terms.zipWithIndex.map { case (t, i) ⇒ reifyParam(VarE(conjunctSubstName(paramE, i), t)) }
               q"((..$args) ⇒ $prevTree)"
             case None ⇒ q"(${reifyParam(paramE)} ⇒ $prevTree)"
           }
@@ -312,7 +312,7 @@ class Macros(val c: whitebox.Context) {
         val casesTrees: Seq[c.Tree] = cases.map {
           // However, at this point a MatchE() could contain a CurriedE() with multiple arguments,
           // as a result of possibly simplifying nested CurriedE().
-          case CurriedE(PropE(fvName, fvType) :: rest, body) ⇒
+          case CurriedE(VarE(fvName, fvType) :: rest, body) ⇒
             // Generate cq"$pat => $expr" where pat = pq"Constructor(..$Strings)".
             val pat = fvType.caseObjectName match {
               case Some(constructor) ⇒ pq"_ : ${TermName(constructor)}.type"
@@ -326,13 +326,15 @@ class Macros(val c: whitebox.Context) {
     }
   }
 
-  // This function is for testing only.
-  def testReifyTypeImpl[U: c.WeakTypeTag]: c.Expr[TypeExpr] = {
+  private val freshIdentForFreshVar = new FreshIdents("zZ")
+
+  def freshVarImpl[U: c.WeakTypeTag]: c.Expr[VarE] = {
     val typeU: c.Type = c.weakTypeOf[U]
-    val result = buildTypeExpr(typeU)
-    if (debug) c.info(c.enclosingPosition, s"Recognized type from type $typeU is ${result.prettyPrint}", force = true)
+    val typeUExpr = buildTypeExpr(typeU)
+    if (debug) c.info(c.enclosingPosition, s"Built type expression ${typeUExpr.prettyPrint} from type $typeU", force = true)
+    val ident = freshIdentForFreshVar()
     import LiftedAST._
-    c.Expr[TypeExpr](q"$result")
+    c.Expr[VarE](q"VarE($ident, $typeUExpr)")
   }
 
   // This function is for testing buildTypeExpr().
@@ -353,7 +355,7 @@ class Macros(val c: whitebox.Context) {
     val result = typeU.paramLists match {
       case Nil ⇒ inhabitOneInternal(buildTypeExpr(typeU))()
       case lists ⇒
-        val givenVars = lists.flatten.map(s ⇒ PropE(s.name.decodedName.toString, buildTypeExpr(s.typeSignature)))
+        val givenVars = lists.flatten.map(s ⇒ VarE(s.name.decodedName.toString, buildTypeExpr(s.typeSignature)))
         val resultType = buildTypeExpr(typeU.finalResultType)
         val typeStructure = givenVars.reverse.foldLeft(resultType) { case (prev, t) ⇒ t.tExpr ->: prev }
         inhabitOneInternal(typeStructure) { term ⇒ givenVars.foldLeft(term) { case (prev, v) ⇒ AppE(prev, v) } }
@@ -376,10 +378,10 @@ class Macros(val c: whitebox.Context) {
     // TODO: Perhaps we can support `implement` with a specified type argument and no auto-detection of enclosing owner's type.
 
     // We need to obtain the actual type of the given terms, rather than the `Any` type as specified in the type signature.
-    val givenVars: Seq[(PropE, c.Tree)] = values.zipWithIndex
+    val givenVars: Seq[(VarE, c.Tree)] = values.zipWithIndex
       // The given values will be marked as arguments with name `arg1`, `arg2`, etc.,
       // so that they do not mix with automatic variables in the generated closed term.
-      .map { case (v, i) ⇒ (PropE(s"arg${i + 1}", buildTypeExpr(v.actualType)), v.tree) }
+      .map { case (v, i) ⇒ (VarE(s"arg${i + 1}", buildTypeExpr(v.actualType)), v.tree) }
     val givenVarsAsArgs = givenVars.map(_._1)
     val typeStructure = givenVarsAsArgs.reverse.foldLeft(typeUT) { case (prev, t) ⇒ t.tExpr ->: prev }
     inhabitOneInternal(typeStructure, givenVars.toMap, createLambdas = true) { term ⇒
@@ -391,8 +393,8 @@ class Macros(val c: whitebox.Context) {
 
   def allOfTypeImplWithValues[U: c.WeakTypeTag](values: c.Expr[Any]*): c.Tree = {
     val typeUT: TypeExpr = buildTypeExpr(c.weakTypeOf[U])
-    val givenVars: Seq[(PropE, c.Tree)] = values.zipWithIndex
-      .map { case (v, i) ⇒ (PropE(s"arg${i + 1}", buildTypeExpr(v.actualType)), v.tree) }
+    val givenVars: Seq[(VarE, c.Tree)] = values.zipWithIndex
+      .map { case (v, i) ⇒ (VarE(s"arg${i + 1}", buildTypeExpr(v.actualType)), v.tree) }
     val givenVarsAsArgs = givenVars.map(_._1)
     val typeStructure = givenVarsAsArgs.reverse.foldLeft(typeUT) { case (prev, t) ⇒ t.tExpr ->: prev }
     inhabitAllInternal(typeStructure, givenVars.toMap) { term ⇒ givenVarsAsArgs.foldLeft(term) { case (prev, v) ⇒ AppE(prev, v) } }
@@ -412,7 +414,7 @@ class Macros(val c: whitebox.Context) {
     */
   private def inhabitOneInternal(
     typeStructure: TypeExpr,
-    givenArgs: Map[PropE, c.Tree] = Map(),
+    givenArgs: Map[VarE, c.Tree] = Map(),
     createLambdas: Boolean = false
   )(
     transform: TermExpr ⇒ TermExpr = identity
@@ -428,7 +430,7 @@ class Macros(val c: whitebox.Context) {
 
   }
 
-  private def returnTerm(termFound: TermExpr, givenArgs: Map[PropE, c.Tree], createLambdas: Boolean): c.Tree = {
+  private def returnTerm(termFound: TermExpr, givenArgs: Map[VarE, c.Tree], createLambdas: Boolean): c.Tree = {
     import LiftedAST._
     val prettyTerm = if (showReturningTerm) termFound.toString else termFound.prettyPrintWithParentheses(0)
     c.info(c.enclosingPosition, s"Returning term: $prettyTerm", force = true)
@@ -437,11 +439,11 @@ class Macros(val c: whitebox.Context) {
       resultCodeTree
     } else {
       termFound match {
-        case CurriedE(PropE(_, ConjunctT(termTypes)) :: _, _) if termTypes.length <= 3 ⇒
+        case CurriedE(VarE(_, ConjunctT(termTypes)) :: _, _) if termTypes.length <= 3 ⇒
           val functionName = TypeName(s"Function${termTypes.length}Lambda")
           val functionNameType = tq"$functionName"
           q"new $functionNameType($resultCodeTree, $termFound)"
-        case CurriedE(PropE(_, _) :: _, _) ⇒ q"new _root_.io.chymyst.ch.Function1Lambda($resultCodeTree, $termFound)"
+        case CurriedE(VarE(_, _) :: _, _) ⇒ q"new _root_.io.chymyst.ch.Function1Lambda($resultCodeTree, $termFound)"
         case _ ⇒ resultCodeTree
       }
     }
@@ -453,7 +455,7 @@ class Macros(val c: whitebox.Context) {
 
   private def inhabitAllInternal(
     typeStructure: TypeExpr,
-    givenArgs: Map[PropE, c.Tree]
+    givenArgs: Map[VarE, c.Tree]
   )(
     transform: TermExpr ⇒ TermExpr
   ): c.Tree = {
@@ -476,6 +478,4 @@ object Macros {
 
   // These methods are for testing only.
   private[ch] def testType[U]: (String, String) = macro Macros.testTypeImpl[U]
-
-  private[ch] def testReifyType[U]: TypeExpr = macro Macros.testReifyTypeImpl[U]
 }

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -285,8 +285,8 @@ class Macros(val c: whitebox.Context) {
             p,
             ConjunctE(termTypes.zipWithIndex.map { case (t, i) ⇒ VarE(conjunctSubstName(p, i), t) }),
             prev
-          ).simplify()
-        }.simplify(withEta = true)
+          ).simplifyOnce()
+        }.simplifyOnce(withEta = true)
 
         // Need to be careful to substitute arguments that are of type ConjunctT, because they represent java-style arg groups.
         heads.reverse.foldLeft(reifyTermShort(replacedBody)) { case (prevTree, paramE) ⇒

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -335,13 +335,6 @@ class Macros(val c: whitebox.Context) {
     c.Expr[TypeExpr](q"$result")
   }
 
-  def testReifyTermsImpl[U: c.WeakTypeTag]: c.Expr[List[TermExpr]] = {
-    val typeU: c.Type = c.weakTypeOf[U]
-    val result: List[TermExpr] = TheoremProver.findProofs(buildTypeExpr(typeU))._1
-    import LiftedAST._
-    c.Expr[List[TermExpr]](q"$result")
-  }
-
   // This function is for testing buildTypeExpr().
   def testTypeImpl[T: c.WeakTypeTag]: c.Expr[(String, String)] = {
     val typeT: c.Type = c.weakTypeOf[T]

--- a/src/main/scala/io/chymyst/ch/Sequent.scala
+++ b/src/main/scala/io/chymyst/ch/Sequent.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 // Premises are straight ordered, so (A, B, C) |- D is Sequent(List(A, B, C), D, _)
 // New bound variables are always introduced fresh, so the generated code never has any need for alpha-conversion.
 final case class Sequent(premises: List[TypeExpr], goal: TypeExpr, freshVar: FreshIdents) {
-  lazy val premiseVars: List[PropE] = premises.map(PropE(freshVar(), _))
+  lazy val premiseVars: List[VarE] = premises.map(VarE(freshVar(), _))
 
   /** Assuming that p takes as many arguments as our premises, substitute all premises into p.
     * This will construct the term AppE( AppE( AppE(p, premise1), premise2), premise3)

--- a/src/main/scala/io/chymyst/ch/Sequent.scala
+++ b/src/main/scala/io/chymyst/ch/Sequent.scala
@@ -13,14 +13,14 @@ final case class Sequent(premises: List[TypeExpr], goal: TypeExpr, freshVar: Fre
     * @param p Proof term to apply to our premises.
     * @return Resulting term.
     */
-  def substituteInto(p: TermExpr): TermExpr = TermExpr.applyToVars(p, premiseVars).simplify()
+  def substituteInto(p: TermExpr): TermExpr = TermExpr.applyToVars(p, premiseVars).simplifyOnce()
 
   /** Construct a function term that takes all the sequent's premises as arguments and returns a given term.
     *
     * @param result A given term that should use the sequent's `premiseVars`.
     * @return A function term.
     */
-  def constructResultTerm(result: TermExpr): TermExpr = CurriedE(premiseVars, result).simplify()
+  def constructResultTerm(result: TermExpr): TermExpr = CurriedE(premiseVars, result).simplifyOnce()
 
   override lazy val toString: String = s"[${premises.map(_.prettyPrint).mkString("; ")} |- ${goal.prettyPrint}]"
 }

--- a/src/main/scala/io/chymyst/ch/TermExpr.scala
+++ b/src/main/scala/io/chymyst/ch/TermExpr.scala
@@ -229,7 +229,10 @@ object TermExpr {
 }
 
 sealed trait TermExpr {
+  // Syntax helpers.
   def apply(y: TermExpr): TermExpr = AppE(this, y)
+
+  def equiv(y: TermExpr): Boolean = simplify == y.simplify
 
   def informationLossScore = (
     ()

--- a/src/main/scala/io/chymyst/ch/TermExpr.scala
+++ b/src/main/scala/io/chymyst/ch/TermExpr.scala
@@ -442,6 +442,7 @@ final case class ConjunctE(terms: Seq[TermExpr]) extends TermExpr {
 final case class ProjectE(index: Int, term: TermExpr) extends TermExpr {
   def getProjection: Option[TermExpr] = term match {
     case c: ConjunctE ⇒ Some(c.terms(index))
+    case c: NamedConjunctE ⇒ Some(c.terms(index))
     case _ ⇒ None
   }
 

--- a/src/main/scala/io/chymyst/ch/TheoremProver.scala
+++ b/src/main/scala/io/chymyst/ch/TheoremProver.scala
@@ -91,7 +91,7 @@ object TheoremProver {
       val transformedProofs = explodedNewProofs.map(ruleResult.backTransform)
       val t0 = System.currentTimeMillis()
 
-      val result = transformedProofs.map(_.simplify()).distinct.sortBy(_.informationLossScore).take(maxTermsToSelect(sequent))
+      val result = transformedProofs.map(_.simplifyOnce()).distinct.sortBy(_.informationLossScore).take(maxTermsToSelect(sequent))
       // Note: at this point, it is a mistake to do prettyRename, because we are calling this function recursively.
       // We will call prettyRename() at the very end of the proof search.
       if (debug) {
@@ -151,7 +151,7 @@ object TheoremProver {
               fromNoninvertibleRules ++ fromAxioms
             //              }
           }
-          val termsFound = fromRules.map(_.simplify()).distinct
+          val termsFound = fromRules.map(_.simplifyOnce()).distinct
           if (debug || debugTrace) {
             val termsMessage = termsFound.length match {
               case 0 ⇒ "no terms"

--- a/src/main/scala/io/chymyst/ch/package.scala
+++ b/src/main/scala/io/chymyst/ch/package.scala
@@ -78,6 +78,11 @@ package object ch {
     }
   }
 
+  implicit class WithLambdaCalculus(val x: TermExpr) extends AnyVal {
+    def apply(y: TermExpr): TermExpr = AppE(x, y)
+    
+  }
+
   /** Create a new fresh variable term of given type.
     *
     * @tparam X Type expression that will be assigned to the new variable.

--- a/src/main/scala/io/chymyst/ch/package.scala
+++ b/src/main/scala/io/chymyst/ch/package.scala
@@ -78,11 +78,6 @@ package object ch {
     }
   }
 
-  implicit class WithLambdaCalculus(val x: TermExpr) extends AnyVal {
-    def apply(y: TermExpr): TermExpr = AppE(x, y)
-    
-  }
-
   /** Create a new fresh variable term of given type.
     *
     * @tparam X Type expression that will be assigned to the new variable.

--- a/src/main/scala/io/chymyst/ch/package.scala
+++ b/src/main/scala/io/chymyst/ch/package.scala
@@ -74,9 +74,17 @@ package object ch {
       case g: Function1Lambda[_, _] ⇒ g.lambdaTerm
       case g: Function2Lambda[_, _, _] ⇒ g.lambdaTerm
       case g: Function3Lambda[_, _, _, _] ⇒ g.lambdaTerm
-      case _ ⇒ throw new Exception("Used `.lambdaTerm` on an expression that has no attached lambda-term")
+      case _ ⇒ throw new Exception("Called `.lambdaTerm` on an expression that has no attached lambda-term")
     }
   }
+
+  /** Create a new fresh variable term of given type.
+    *
+    * @tparam X Type expression that will be assigned to the new variable.
+    * @return A new variable.
+    */
+  def freshVar[X]: VarE = macro Macros.freshVarImpl[X]
+
 }
 
 // Note: for some reason, a macro with arguments cannot properly infer types.

--- a/src/main/scala/io/chymyst/ch/package.scala
+++ b/src/main/scala/io/chymyst/ch/package.scala
@@ -63,13 +63,20 @@ package object ch {
     */
   def ofType[U](values: Any*): U = macro Macros.ofTypeImplWithValues[U]
 
-  /** Obtain a list of lambda-terms implementing a given type expression.
+  /** Obtain the lambda-term from an enriched expression that results from `ofType`.
+    * Will throw an exception if the expression is not obtained from `ofType` or `allOfType`.
     *
-    * @tparam U The type expression to be implemented.
-    * @return A list of abstract syntax trees representing the (typed) lambda-terms,
-    *         each implementing the given type `U`.
+    * @param x An expression that was automatically produced by `ofType` or `allOfType`.
     */
-  def lambdaTerms[U]: List[TermExpr] = macro Macros.testReifyTermsImpl[U]
+  implicit class WithLambdaTerm(val x: Any) extends AnyVal {
+    def lambdaTerm: TermExpr = x match {
+      case g: Function0Lambda[_] ⇒ g.lambdaTerm
+      case g: Function1Lambda[_, _] ⇒ g.lambdaTerm
+      case g: Function2Lambda[_, _, _] ⇒ g.lambdaTerm
+      case g: Function3Lambda[_, _, _, _] ⇒ g.lambdaTerm
+      case _ ⇒ throw new Exception("Used `.lambdaTerm` on an expression that has no attached lambda-term")
+    }
+  }
 }
 
 // Note: for some reason, a macro with arguments cannot properly infer types.

--- a/src/test/scala/io/chymyst/ch/unit/ApiSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/ApiSpec.scala
@@ -153,4 +153,12 @@ class ApiSpec extends LawChecking {
     f._1(123) shouldEqual 123
     f._2("abc") shouldEqual "abc"
   }
+
+  behavior of "java-style functions"
+
+  it should "handle function with zero arguments" in {
+    // TODO: fix this
+    "val f = ofType[Int ⇒ () ⇒ Int]" shouldNot compile
+//    f(123)() shouldEqual 123
+  }
 }

--- a/src/test/scala/io/chymyst/ch/unit/LJTSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LJTSpec.scala
@@ -81,14 +81,14 @@ class LJTSpec extends FlatSpec with Matchers {
     followsFromAxioms(Sequent(List(TP("3"), TP("2"), TP("1")), TP("0"), freshVar)) shouldEqual ((Seq(), Seq()))
 
     followsFromAxioms(Sequent(List(TP("3"), TP("2"), TP("1")), TP("1"), freshVar)) shouldEqual ((Seq(
-      CurriedE(List(PropE("x4", TP("3")), PropE("x5", TP("2")), PropE("x6", TP("1"))), PropE("x6", TP("1")))
+      CurriedE(List(VarE("x4", TP("3")), VarE("x5", TP("2")), VarE("x6", TP("1"))), VarE("x6", TP("1")))
     ), Seq()))
   }
 
   it should "produce several proofs from the Id axiom" in {
     followsFromAxioms(Sequent(List(TP("1"), TP("2"), TP("1")), TP("1"), freshVar)) shouldEqual ((Seq(
-      CurriedE(List(PropE("x7", TP("1")), PropE("x8", TP("2")), PropE("x9", TP("1"))), PropE("x7", TP("1"))),
-      CurriedE(List(PropE("x7", TP("1")), PropE("x8", TP("2")), PropE("x9", TP("1"))), PropE("x9", TP("1")))
+      CurriedE(List(VarE("x7", TP("1")), VarE("x8", TP("2")), VarE("x9", TP("1"))), VarE("x7", TP("1"))),
+      CurriedE(List(VarE("x7", TP("1")), VarE("x8", TP("2")), VarE("x9", TP("1"))), VarE("x9", TP("1")))
     ), Seq()))
   }
 
@@ -96,13 +96,13 @@ class LJTSpec extends FlatSpec with Matchers {
     val sequent = Sequent(List(TP("1")), TP("1"), freshVar)
     val terms = TheoremProver.findTermExprs(sequent)
     terms.length shouldEqual 1
-    TermExpr.equiv(terms.head, CurriedE(List(PropE("x1", TP("1"))), PropE("x1", TP("1")))) shouldEqual true
+    TermExpr.equiv(terms.head, CurriedE(List(VarE("x1", TP("1"))), VarE("x1", TP("1")))) shouldEqual true
 
     val sequent2 = Sequent(List(TP("3"), TP("2"), TP("1")), TP("2"), freshVar)
     val terms2 = TheoremProver.findTermExprs(sequent2)
     terms2.length shouldEqual 1
     TermExpr.equiv(terms2.head,
-      CurriedE(List(PropE("x2", TP("3")), PropE("x3", TP("2")), PropE("x4", TP("1"))), PropE("x3", TP("2")))
+      CurriedE(List(VarE("x2", TP("3")), VarE("x3", TP("2")), VarE("x4", TP("1"))), VarE("x3", TP("2")))
     ) shouldEqual true
   }
 
@@ -110,7 +110,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val sequent = Sequent(List(TP("1"), TP("2")), TP("1"), freshVar)
     val terms = TheoremProver.findTermExprs(sequent)
     terms.length shouldEqual 1
-    TermExpr.equiv(terms.head, CurriedE(List(PropE("a", TP("1")), PropE("b", TP("2"))), PropE("a", TP("1")))) shouldEqual true
+    TermExpr.equiv(terms.head, CurriedE(List(VarE("a", TP("1")), VarE("b", TP("2"))), VarE("a", TP("1")))) shouldEqual true
   }
 
   behavior of "proof search - high-level API, rule ->R"
@@ -119,7 +119,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val typeExpr = TP("1") ->: TP("1")
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("1"))), PropE("x", TP("1")))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("1"))), VarE("x", TP("1")))) shouldEqual true
   }
 
   it should "find proof term for the K combinator using rule ->R" in {
@@ -127,7 +127,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
     println(proofs.head)
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("1")), PropE("y", TP("2"))), PropE("x", TP("1")))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("1")), VarE("y", TP("2"))), VarE("x", TP("1")))) shouldEqual true
   }
 
   it should "find proof term for the flipped K combinator using rule ->R" in {
@@ -135,7 +135,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
     println(proofs.head)
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("2")), PropE("y", TP("1"))), PropE("y", TP("1")))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("2")), VarE("y", TP("1"))), VarE("y", TP("1")))) shouldEqual true
   }
 
   it should "find proof term for the constant function with 2 arguments using rule ->R" in {
@@ -143,7 +143,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
     println(proofs.head)
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("0")), PropE("y", TP("1")), PropE("z", TP("2"))), PropE("x", TP("0")))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("0")), VarE("y", TP("1")), VarE("z", TP("2"))), VarE("x", TP("0")))) shouldEqual true
   }
 
   it should "find proof term for the 1-switched constant function with 2 arguments using rule ->R" in {
@@ -151,7 +151,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
     println(proofs.head)
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("0")), PropE("y", TP("1")), PropE("z", TP("2"))), PropE("y", TP("1")))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("0")), VarE("y", TP("1")), VarE("z", TP("2"))), VarE("y", TP("1")))) shouldEqual true
   }
 
   it should "find proof term for the 2-switched constant function with 2 arguments using rule ->R" in {
@@ -159,7 +159,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
     println(proofs.head)
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("0")), PropE("y", TP("1")), PropE("z", TP("2"))), PropE("z", TP("2")))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("0")), VarE("y", TP("1")), VarE("z", TP("2"))), VarE("z", TP("2")))) shouldEqual true
   }
 
   behavior of "proof search - high-level API, rule +Rn"
@@ -169,7 +169,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val typeExpr = TP("1") ->: disjunctT
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("1"))), DisjunctE(0, 2, PropE("x", TP("1")), disjunctT))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("1"))), DisjunctE(0, 2, VarE("x", TP("1")), disjunctT))) shouldEqual true
   }
 
   it should "find proof term for simple instance of +Rn with several disjuncts" in {
@@ -177,7 +177,7 @@ class LJTSpec extends FlatSpec with Matchers {
     val typeExpr = TP("2") ->: disjunctT
     val proofs = TheoremProver.findProofs(typeExpr)._1
     proofs.length shouldEqual 1
-    TermExpr.equiv(proofs.head, CurriedE(List(PropE("x", TP("2"))), DisjunctE(1, 3, PropE("x", TP("2")), disjunctT))) shouldEqual true
+    TermExpr.equiv(proofs.head, CurriedE(List(VarE("x", TP("2"))), DisjunctE(1, 3, VarE("x", TP("2")), disjunctT))) shouldEqual true
   }
 
   it should "inhabit type using +Rn" in {

--- a/src/test/scala/io/chymyst/ch/unit/LJTSpec4.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LJTSpec4.scala
@@ -1,7 +1,7 @@
 package io.chymyst.ch.unit
 
 import io.chymyst.ch._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 class LJTSpec4 extends FlatSpec with Matchers {
 
@@ -9,5 +9,6 @@ class LJTSpec4 extends FlatSpec with Matchers {
   behavior of "misc. tests"
 
   it should "work" in {
+
   }
 }

--- a/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
@@ -9,7 +9,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
 
   it should "produce result terms" in {
     val terms1 = ofType[Int ⇒ Int]
-    terms1.lambdaTerm shouldEqual CurriedE(List(PropE("a", BasicT("Int"))), PropE("a", BasicT("Int")))
+    terms1.lambdaTerm shouldEqual CurriedE(List(VarE("a", BasicT("Int"))), VarE("a", BasicT("Int")))
 
     val terms2 = allOfType[Int ⇒ Int ⇒ Int]
     terms2.length shouldEqual 2
@@ -94,7 +94,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
 
     idFunc.lambdaTerm.prettyPrint shouldEqual "a ⇒ a"
 
-    val readerTerm = PropE("rxa", TP("X") ->: TP("A"))
+    val readerTerm = VarE("rxa", TP("X") ->: TP("A"))
 
     val appl1 = TermExpr.simplifyWithEtaUntilStable(AppE(AppE(TermExpr.substTypeVar(TP("B"), TP("A"), mapReaderTerm), readerTerm), idFunc.lambdaTerm))
 
@@ -110,11 +110,11 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
 
     fmapReaderTerm.prettyPrint shouldEqual "a ⇒ b ⇒ c ⇒ a (b c)"
 
-    val readerTerm = PropE("rxa", TP("X") ->: TP("A"))
-    val aTerm = PropE("a", TP("A"))
+    val readerTerm = VarE("rxa", TP("X") ->: TP("A"))
+    val aTerm = VarE("a", TP("A"))
 
-    val f1Term = PropE("f1", TP("A") ->: TP("B"))
-    val f2Term = PropE("f2", TP("B") ->: TP("C"))
+    val f1Term = VarE("f1", TP("A") ->: TP("B"))
+    val f2Term = VarE("f2", TP("B") ->: TP("C"))
 
     // fmap f1 . fmap f2 = fmap (f1 . f2)
     val fmapF1 = AppE(fmapReaderTerm, f1Term)

--- a/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
@@ -50,6 +50,26 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
     f3.map(_.prettyPrint) shouldEqual Seq("a ⇒ a._1", "a ⇒ a._2")
   }
 
+  it should "produce result terms for functions of 2 and 3 arguments" in {
+    val terms1 = lambdaTerms[(Int, Int) ⇒ Int]
+    terms1.length shouldEqual 2
+
+    val f1 = allOfType[(Int, Int) ⇒ Int]
+    f1.flatMap(TermExpr.lambdaTerm).length shouldEqual 2
+
+    val terms2 = lambdaTerms[(Int, Int, Int) ⇒ Int]
+    terms2.length shouldEqual 3
+
+    val f2 = allOfType[(Int, Int, Int) ⇒ Int]
+    f2.flatMap(TermExpr.lambdaTerm).length shouldEqual 3
+  }
+
+  it should "produce no lambda-terms when `implement` is used" in {
+    val terms1: Int ⇒ Int = implement
+
+    TermExpr.lambdaTerm(terms1) shouldEqual None
+  }
+
   it should "symbolically lambda-verify identity law for map on Reader monad" in {
     type R[X, A] = X ⇒ A
 
@@ -99,9 +119,13 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
     appl1 shouldEqual appl2
   }
 
-  it should "return lambda terms together with the function" in {
-    def f2[A]: Unit ⇒ Either[A ⇒ A, Unit] = implement
+  it should "return lambda terms together with the function when using `ofType` but not when using `implement`" in {
+    def f2[A] = ofType[Unit ⇒ Either[A ⇒ A, Unit]]
 
     TermExpr.lambdaTerm(f2).map(_.prettyPrint) shouldEqual Some("a ⇒ (0 + Right(a))")
+
+    def f2a[A]: Unit ⇒ Either[A ⇒ A, Unit] = implement
+
+    TermExpr.lambdaTerm(f2a) shouldEqual None
   }
 }

--- a/src/test/scala/io/chymyst/ch/unit/TermExprSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/TermExprSpec.scala
@@ -86,7 +86,7 @@ class TermExprSpec extends FlatSpec with Matchers {
     val termExpr0 = VarE("y", TP("1"))
     val termExpr1 = CurriedE(List(VarE("x", TP("1") ->: TP("1"))), termExpr0) // x: A -> x
     val termExpr2 = AppE(termExpr1, VarE("z", TP("1") ->: TP("1")))
-    termExpr2.simplify() shouldEqual termExpr0 // (x: A -> y)(z) == y
+    termExpr2.simplifyOnce() shouldEqual termExpr0 // (x: A -> y)(z) == y
   }
 
   it should "simplify nested terms" in {
@@ -94,11 +94,11 @@ class TermExprSpec extends FlatSpec with Matchers {
     val x2 = VarE("x2", TP("1") ->: TP("2")) // x2: A → B
     val x3 = VarE("x3", TP("1")) // x3: A
     val t1 = AppE(f1, VarE("y", TP("2")))
-    t1.simplify() shouldEqual CurriedE(List(VarE("x5", TP("1"))), VarE("y", TP("2")))
+    t1.simplifyOnce() shouldEqual CurriedE(List(VarE("x5", TP("1"))), VarE("y", TP("2")))
 
     // x3:A -> (x2:A → B) -> (x4:B  -> x5:A -> x4:B) ( (x2:A → B)(x3:A) ) (x3:A)
     val termExpr4 = CurriedE(List(x3, x2), AppE(AppE(f1, AppE(x2, x3)), x3))
-    termExpr4.simplify() shouldEqual CurriedE(List(x3, x2), AppE(x2, x3))
+    termExpr4.simplifyOnce() shouldEqual CurriedE(List(x3, x2), AppE(x2, x3))
   }
 
   behavior of "Sequent#constructResultTerm"

--- a/src/test/scala/io/chymyst/ch/unit/TermExprSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/TermExprSpec.scala
@@ -7,33 +7,33 @@ class TermExprSpec extends FlatSpec with Matchers {
 
   behavior of "TermExpr#renameVar"
 
-  val termExpr1 = CurriedE(List(PropE("x2", TP("3")), PropE("x3", TP("2")), PropE("x4", TP("1"))), PropE("x3", TP("2")))
-  val termExpr2 = CurriedE(List(PropE("x2", TP("3")), PropE("x3", TP("2")), PropE("x4", TP("1"))), PropE("x1", TP("2")))
-  val termExpr3 = CurriedE(List(PropE("x1", TP("2"))), termExpr2)
+  val termExpr1 = CurriedE(List(VarE("x2", TP("3")), VarE("x3", TP("2")), VarE("x4", TP("1"))), VarE("x3", TP("2")))
+  val termExpr2 = CurriedE(List(VarE("x2", TP("3")), VarE("x3", TP("2")), VarE("x4", TP("1"))), VarE("x1", TP("2")))
+  val termExpr3 = CurriedE(List(VarE("x1", TP("2"))), termExpr2)
 
   it should "rename one variable" in {
-    termExpr1.renameAllVars(Seq("x2"), Seq("y2")) shouldEqual CurriedE(List(PropE("y2", TP("3")), PropE("x3", TP("2")), PropE("x4", TP("1"))), PropE("x3", TP("2")))
-    termExpr1.renameAllVars(Seq("x3"), Seq("y3")) shouldEqual CurriedE(List(PropE("x2", TP("3")), PropE("y3", TP("2")), PropE("x4", TP("1"))), PropE("y3", TP("2")))
-    termExpr2.renameAllVars(Seq("x1"), Seq("y1")) shouldEqual CurriedE(List(PropE("x2", TP("3")), PropE("x3", TP("2")), PropE("x4", TP("1"))), PropE("y1", TP("2")))
-    termExpr3.renameAllVars(Seq("x1"), Seq("y1")) shouldEqual CurriedE(List(PropE("y1", TP("2"))), CurriedE(List(PropE("x2", TP("3")), PropE("x3", TP("2")), PropE("x4", TP("1"))), PropE("y1", TP("2"))))
+    termExpr1.renameAllVars(Seq("x2"), Seq("y2")) shouldEqual CurriedE(List(VarE("y2", TP("3")), VarE("x3", TP("2")), VarE("x4", TP("1"))), VarE("x3", TP("2")))
+    termExpr1.renameAllVars(Seq("x3"), Seq("y3")) shouldEqual CurriedE(List(VarE("x2", TP("3")), VarE("y3", TP("2")), VarE("x4", TP("1"))), VarE("y3", TP("2")))
+    termExpr2.renameAllVars(Seq("x1"), Seq("y1")) shouldEqual CurriedE(List(VarE("x2", TP("3")), VarE("x3", TP("2")), VarE("x4", TP("1"))), VarE("y1", TP("2")))
+    termExpr3.renameAllVars(Seq("x1"), Seq("y1")) shouldEqual CurriedE(List(VarE("y1", TP("2"))), CurriedE(List(VarE("x2", TP("3")), VarE("x3", TP("2")), VarE("x4", TP("1"))), VarE("y1", TP("2"))))
   }
 
   it should "rename multiple variables" in {
-    termExpr1.renameAllVars(Seq("x2", "x3", "x4"), Seq("y2", "y3", "y4")) shouldEqual CurriedE(List(PropE("y2", TP("3")), PropE("y3", TP("2")), PropE("y4", TP("1"))), PropE("y3", TP("2")))
+    termExpr1.renameAllVars(Seq("x2", "x3", "x4"), Seq("y2", "y3", "y4")) shouldEqual CurriedE(List(VarE("y2", TP("3")), VarE("y3", TP("2")), VarE("y4", TP("1"))), VarE("y3", TP("2")))
   }
 
   behavior of "TermExpr#propositions"
 
   it should "get the list of propositions" in {
-    TermExpr.propositions(CurriedE(List(PropE("A", TP("A"))), AppE(PropE("B", TP("B") ->: TP("A")), PropE("B", TP("B"))))) shouldEqual Seq(PropE("A", TP("A")), PropE("B", TP("B") ->: TP("A")), PropE("B", TP("B")))
+    TermExpr.propositions(CurriedE(List(VarE("A", TP("A"))), AppE(VarE("B", TP("B") ->: TP("A")), VarE("B", TP("B"))))) shouldEqual Seq(VarE("A", TP("A")), VarE("B", TP("B") ->: TP("A")), VarE("B", TP("B")))
   }
 
   behavior of "TermExpr#prettyPrint"
 
   it should "rename variables without name clash" in {
-    val a = PropE("a", TP("A") ->: TP("B"))
-    val c = PropE("c", TP("A"))
-    val b = PropE("b", ((TP("A") ->: TP("B")) ->: TP("B")) ->: TP("B"))
+    val a = VarE("a", TP("A") ->: TP("B"))
+    val c = VarE("c", TP("A"))
+    val b = VarE("b", ((TP("A") ->: TP("B")) ->: TP("B")) ->: TP("B"))
     // b ⇒ c ⇒ b (a ⇒ a c)  is of type (((A ⇒ B) ⇒ B) ⇒ B) ⇒ A ⇒ B
     val termExpr = CurriedE(List(b, c), AppE(b, CurriedE(List(a), AppE(a, c))))
     termExpr.toString shouldEqual "\\((b:((A ⇒ B) ⇒ B) ⇒ B) ⇒ (c:A) ⇒ (b \\((a:A ⇒ B) ⇒ (a c))))"
@@ -58,7 +58,7 @@ class TermExprSpec extends FlatSpec with Matchers {
   behavior of "information loss"
 
   it should "compute permutation score for conjunctions" in {
-    val c = ConjunctE(Seq(PropE("a", TP("A")), PropE("b", TP("B"))))
+    val c = ConjunctE(Seq(VarE("a", TP("A")), VarE("b", TP("B"))))
     val t = ConjunctE(Seq(
       ProjectE(0, c),
       ProjectE(1, c)
@@ -83,18 +83,18 @@ class TermExprSpec extends FlatSpec with Matchers {
   behavior of "TermExpr#simplify"
 
   it should "simplify identity function application" in {
-    val termExpr0 = PropE("y", TP("1"))
-    val termExpr1 = CurriedE(List(PropE("x", TP("1") ->: TP("1"))), termExpr0) // x: A -> x
-    val termExpr2 = AppE(termExpr1, PropE("z", TP("1") ->: TP("1")))
+    val termExpr0 = VarE("y", TP("1"))
+    val termExpr1 = CurriedE(List(VarE("x", TP("1") ->: TP("1"))), termExpr0) // x: A -> x
+    val termExpr2 = AppE(termExpr1, VarE("z", TP("1") ->: TP("1")))
     termExpr2.simplify() shouldEqual termExpr0 // (x: A -> y)(z) == y
   }
 
   it should "simplify nested terms" in {
-    val f1 = CurriedE(List(PropE("x4", TP("2")), PropE("x5", TP("1"))), PropE("x4", TP("2"))) // f1: (x4:B -> x5:A -> x4:B)
-    val x2 = PropE("x2", TP("1") ->: TP("2")) // x2: A → B
-    val x3 = PropE("x3", TP("1")) // x3: A
-    val t1 = AppE(f1, PropE("y", TP("2")))
-    t1.simplify() shouldEqual CurriedE(List(PropE("x5", TP("1"))), PropE("y", TP("2")))
+    val f1 = CurriedE(List(VarE("x4", TP("2")), VarE("x5", TP("1"))), VarE("x4", TP("2"))) // f1: (x4:B -> x5:A -> x4:B)
+    val x2 = VarE("x2", TP("1") ->: TP("2")) // x2: A → B
+    val x3 = VarE("x3", TP("1")) // x3: A
+    val t1 = AppE(f1, VarE("y", TP("2")))
+    t1.simplify() shouldEqual CurriedE(List(VarE("x5", TP("1"))), VarE("y", TP("2")))
 
     // x3:A -> (x2:A → B) -> (x4:B  -> x5:A -> x4:B) ( (x2:A → B)(x3:A) ) (x3:A)
     val termExpr4 = CurriedE(List(x3, x2), AppE(AppE(f1, AppE(x2, x3)), x3))
@@ -106,8 +106,8 @@ class TermExprSpec extends FlatSpec with Matchers {
   it should "produce result terms in correct order" in {
     val sequent = Sequent(List(TP("1"), TP("2"), TP("3")), TP("1"), new FreshIdents("t"))
     val premiseVars = sequent.premiseVars
-    premiseVars shouldEqual List(PropE("t1", TP("1")), PropE("t2", TP("2")), PropE("t3", TP("3")))
+    premiseVars shouldEqual List(VarE("t1", TP("1")), VarE("t2", TP("2")), VarE("t3", TP("3")))
     val term = sequent.constructResultTerm(premiseVars.head)
-    term shouldEqual CurriedE(List(PropE("t1", TP("1")), PropE("t2", TP("2")), PropE("t3", TP("3"))), PropE("t1", TP("1")))
+    term shouldEqual CurriedE(List(VarE("t1", TP("1")), VarE("t2", TP("2")), VarE("t3", TP("3"))), VarE("t1", TP("1")))
   }
 }

--- a/src/test/scala/io/chymyst/ch/unit/TheoremProverSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/TheoremProverSpec.scala
@@ -13,15 +13,15 @@ class TheoremProverSpec extends FlatSpec with Matchers {
     val sequent = Sequent(List(BasicT("1"), BasicT("2")), BasicT("1"), freshVar)
     val terms = TheoremProver.findTermExprs(sequent)
     terms.length shouldEqual 1
-    TermExpr.equiv(terms.head, CurriedE(List(PropE("a", BasicT("1")), PropE("b", BasicT("2"))), PropE("a", BasicT("1")))) shouldEqual true
+    TermExpr.equiv(terms.head, CurriedE(List(VarE("a", BasicT("1")), VarE("b", BasicT("2"))), VarE("a", BasicT("1")))) shouldEqual true
   }
 
   it should "treat constant types as unique type variables and obtain two implementations" in {
     val sequent = Sequent(List(BasicT("1"), BasicT("1")), BasicT("1"), freshVar)
     val terms = TheoremProver.findTermExprs(sequent)
     terms.length shouldEqual 2
-    TermExpr.equiv(terms.head, CurriedE(List(PropE("a", BasicT("1")), PropE("b", BasicT("1"))), PropE("a", BasicT("1")))) shouldEqual true
-    TermExpr.equiv(terms(1), CurriedE(List(PropE("a", BasicT("1")), PropE("b", BasicT("1"))), PropE("b", BasicT("1")))) shouldEqual true
+    TermExpr.equiv(terms.head, CurriedE(List(VarE("a", BasicT("1")), VarE("b", BasicT("1"))), VarE("a", BasicT("1")))) shouldEqual true
+    TermExpr.equiv(terms(1), CurriedE(List(VarE("a", BasicT("1")), VarE("b", BasicT("1"))), VarE("b", BasicT("1")))) shouldEqual true
   }
 
   behavior of "named conjunctions"


### PR DESCRIPTION
Lambda-terms are an experimental feature and should not be output by default.