### PR TITLE
Feature/fix tuple option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val curryhoward: Project = (project in file("."))
   .settings(common)
   .settings(
     organization := "io.chymyst",
-    version := "0.3.0",
+    version := "0.3.1",
 
     licenses := Seq("Apache License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
     homepage := Some(url("https://github.com/Chymyst/curryhoward")),

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -452,7 +452,7 @@ class Macros(val c: whitebox.Context) {
     result
   }
 
-  val MAX_TERM_SIZE_FOR_LAMBDA_EXPORT = 128
+  val MAX_TERM_SIZE_FOR_LAMBDA_EXPORT = 1024
 
   private def inhabitAllInternal(
     typeStructure: TypeExpr,

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -1,7 +1,5 @@
 package io.chymyst.ch
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import scala.language.experimental.macros
 //import scala.reflect.macros.blackbox
 import scala.reflect.macros.whitebox
@@ -452,7 +450,7 @@ class Macros(val c: whitebox.Context) {
     result
   }
 
-  val MAX_TERM_SIZE_FOR_LAMBDA_EXPORT = 1024
+  val MAX_TERM_SIZE_FOR_LAMBDA_EXPORT = 256
 
   private def inhabitAllInternal(
     typeStructure: TypeExpr,

--- a/src/main/scala/io/chymyst/ch/Macros.scala
+++ b/src/main/scala/io/chymyst/ch/Macros.scala
@@ -334,7 +334,6 @@ class Macros(val c: whitebox.Context) {
     val typeUExpr = buildTypeExpr(typeU)
     if (debug) c.info(c.enclosingPosition, s"Built type expression ${typeUExpr.prettyPrint} from type $typeU", force = true)
     val ident: String = Macros.freshIdentForFreshVar()
-    c.info(c.enclosingPosition, s"debug - freshVar output VarE($ident, $typeUExpr)", force = true)
     import LiftedAST._
     c.Expr[VarE](q"VarE($ident, $typeUExpr)")
   }

--- a/src/main/scala/io/chymyst/ch/TheoremProver.scala
+++ b/src/main/scala/io/chymyst/ch/TheoremProver.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable
 
 
 object TheoremProver {
-  private def debug = Macros.options contains "prover"
+  private def debug = true // Macros.options contains "prover"
 
   private def debugTrace = Macros.options contains "trace"
 

--- a/src/main/scala/io/chymyst/ch/TheoremProver.scala
+++ b/src/main/scala/io/chymyst/ch/TheoremProver.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable
 
 
 object TheoremProver {
-  private def debug = true // Macros.options contains "prover"
+  private def debug = Macros.options contains "prover"
 
   private def debugTrace = Macros.options contains "trace"
 

--- a/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
@@ -170,6 +170,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
   }
 
   it should "support filter syntax" in {
+
     final case class C[A](d: Option[(A, A)]) {
       // greedy filter on the product
       def map[B](f: A ⇒ B): C[B] = implement

--- a/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
@@ -173,7 +173,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
 
     final case class C[A](d: Option[(A, A)]) {
       // greedy filter on the product
-      def map[B](f: A ⇒ B): C[B] = implement
+      def map[B](f: A ⇒ B): C[B] = ofType[C[B]](d, f)
 
       def withFilter(p: A ⇒ Boolean): C[A] = C(d filter {
         case (x, y) ⇒ p(x) && p(y)
@@ -188,7 +188,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
     } yield y
 
     c.map(x ⇒ x * 2) shouldEqual C(Some((246, 912)))
-    d(200) shouldEqual C(None)
-    d(500) shouldEqual C(Some((246, 912)))
+    d(500) shouldEqual C(None)
+    d(200) shouldEqual C(Some((246, 912)))
   }
 }

--- a/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
+++ b/src/test/scala/io/chymyst/ch/unit/LambdaTermsSpec.scala
@@ -100,7 +100,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
     val mapReaderAA = TermExpr.substTypeVar(TP("B"), TP("A"), mapReaderTerm)
 
     // map(rxa)(id) = rxa
-     mapReaderAA(readerTerm)(idTermA).equiv(readerTerm) shouldEqual true
+    mapReaderAA(readerTerm)(idTermA).equiv(readerTerm) shouldEqual true
   }
 
   it should "symbolically lambda-verify composition law for fmap on Reader monad" in {
@@ -128,7 +128,7 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
       val fmapF2 = fmapBC(f2Term)
 
       val fmapF1fmapF2rxa = fmapF2(fmapF1(readerTerm))
-      fmapf1f2rxa.equiv( fmapF1fmapF2rxa) shouldEqual true
+      fmapf1f2rxa.equiv(fmapF1fmapF2rxa) shouldEqual true
     }
 
     check()
@@ -167,5 +167,27 @@ class LambdaTermsSpec extends FlatSpec with Matchers {
     def f2a[A]: Unit ⇒ Either[A ⇒ A, Unit] = implement
 
     TermExpr.lambdaTerm(f2a) shouldEqual None
+  }
+
+  it should "support filter syntax" in {
+    final case class C[A](d: Option[(A, A)]) {
+      // greedy filter on the product
+      def map[B](f: A ⇒ B): C[B] = implement
+
+      def withFilter(p: A ⇒ Boolean): C[A] = C(d filter {
+        case (x, y) ⇒ p(x) && p(y)
+      })
+    }
+
+    val c = C(Some((123, 456)))
+    val d: Int ⇒ C[Int] = limit ⇒ for {
+      x ← c
+      y = x * 2
+      if y > limit
+    } yield y
+
+    c.map(x ⇒ x * 2) shouldEqual C(Some((246, 912)))
+    d(200) shouldEqual C(None)
+    d(500) shouldEqual C(Some((246, 912)))
   }
 }


### PR DESCRIPTION
- [x] A bug was found when implementing `map` on an `Option[(A, A)]`: the generated code always returns `None`.
- [x] Cleanups are necessary for the new lambda-terms API.